### PR TITLE
websocket: 支持文本换行和一些样式优化

### DIFF
--- a/src/views/tool/websocket.vue
+++ b/src/views/tool/websocket.vue
@@ -30,7 +30,7 @@
                                 <div v-if="lists.length === 0" style="font-size: 14px;color: #999999">
                                     {{ $t('websocket_log_content') }}
                                 </div>
-                                <div v-else v-for="(item,key) in lists" :key="key">
+                                <div v-else v-for="(item,key) in lists" :key="key" class="item-wrap">
                                     <div class="item" v-if="item.type === 'send'" style="color:green">
                                         {{ $t('websocket_you') }} {{ item.time }}
                                     </div>
@@ -41,8 +41,8 @@
                                         {{ item.time }}
                                     </div>
                                     <div class="item">
-                                        <Icon style="cursor: pointer" type="md-copy" @click="$copy(item.content)"/>
-                                        {{ item.content }}
+                                        <Icon type="md-copy" @click="$copy(item.content)"/>
+                                        <pre class="item-content">{{ item.content }}</pre>
                                     </div>
                                 </div>
                             </div>
@@ -163,9 +163,37 @@ export default {
     },
 }
 </script>
-<style scoped>
+<style lang="less" scoped>
 .lists-block {
     font-size: 14px;
     line-height: 28px;
 }
+
+.item {
+    position: relative;
+
+    &-wrap:not(:first-child) {
+        margin-top: 16px;
+    }
+
+    & /deep/ .ivu-icon {
+        position: absolute;
+        right: 8px;
+        top: 8px;
+        padding: 8px;
+        cursor: pointer;
+        background-color: #fff;
+        border-radius: 5px;
+    }
+
+    &-content {
+        margin: 0;
+        overflow: auto;
+        padding: 8px;
+        background-color: #f0f0f0;
+        border-radius: 5px;
+        line-height: 1.3;
+    }
+}
+
 </style>


### PR DESCRIPTION
现在文本没有换行的话，还需要复制到其他地方格式化阅读，所以支持了一下文本换行。一方面更易于阅读，另一方面，在用于调试的场景中，更应该明确区分空格和换行。

考虑到部分情况可能还是需要压缩显示，如果有这个需求，后续可以考虑支持单条记录的换行/不换行切换。

等宽字体会更适合代码阅读。同时，样式方面较为主观，所以我只简单改了一下。

### 预览

**Before:**

![20220410_013122_SP](https://user-images.githubusercontent.com/25103518/162585390-0f1c6cdc-b50a-4e78-976f-45e67eadee1b.png)

**After:**

![20220410_013331_SP](https://user-images.githubusercontent.com/25103518/162585392-fb795c59-8661-4f17-a1ab-4be5ef7b126f.png)
