### PR TITLE
SM4 对称加密和 hex/base64 转换

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "c-tool",
-    "version": "1.11.0",
+    "version": "1.11.1",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "c-tool",
-            "version": "1.11.0",
+            "version": "1.11.1",
             "dependencies": {
                 "@babel/parser": "^7.17.0",
                 "@prettier/plugin-php": "^0.17.6",

--- a/src/config.js
+++ b/src/config.js
@@ -57,6 +57,7 @@ const tool = [
     {'name': 'variableConversion', 'cat': ['conversion']},
     {'name': 'jwt', 'cat': ['encoder_decoder']},
     {'name': 'hexString', 'cat': ['conversion']},
+    {'name': 'hex2base64', 'cat': ['conversion']},
     {'name': 'text', 'cat': ['other']},
     {'name': 'html', 'cat': ['encoder_decoder']},
     {'name': 'binary', 'cat': ['generate']},
@@ -76,7 +77,7 @@ const feature = {
 const utools = {
     keyword: {
         hash: ['md5', 'sha1', 'sha256', 'sha512', 'sm3'],
-        encrypt: ['AES', 'DES', 'RC4', 'Rabbit', 'TripleDes', 'sm2'],
+        encrypt: ['AES', 'DES', 'RC4', 'Rabbit', 'TripleDes', 'sm2', 'sm4'],
         jwt: ['jwtDecode'],
         hexString: ['hex to string', 'string to hex', '十六进制转字符串', '字符串转十六机制'],
         text: ['文本处理', '大小写转换', '中英文标点转换', '简繁转换', '字符替换', '字符统计', '行去重', '添加行号', '行排序', '过滤行首尾不可见字符', '过滤空行'],

--- a/src/i18n/locales/en/main.i18n.json5
+++ b/src/i18n/locales/en/main.i18n.json5
@@ -67,6 +67,7 @@
     "tool_variableConversion": "Variable Name",
     "tool_jwt": "JWT",
     "tool_hexString": "Hex/String",
+    "tool_hex2base64": "Hex/Base64",
     "tool_text": "Text",
     "tool_html": "Html En/Decode",
     "tool_binary": "trueForm/inverse/complement",

--- a/src/i18n/locales/zh_CN/main.i18n.json5
+++ b/src/i18n/locales/zh_CN/main.i18n.json5
@@ -67,6 +67,7 @@
     "tool_variableConversion": "变量名",
     "tool_jwt": "JWT解码",
     "tool_hexString": "Hex/String",
+    "tool_hex2base64": "Hex/Base64",
     "tool_text": "文本处理",
     "tool_html": "Html编码",
     "tool_binary": "原码/反码/补码",

--- a/src/tool.router.js
+++ b/src/tool.router.js
@@ -135,6 +135,10 @@ const routes = [
         component: r => require(['./views/tool/hexString.vue'], r)
     },
     {
+        path: '/tool/hex2base64',
+        component: r => require(['./views/tool/hex2base64.vue'], r)
+    },
+    {
         path: '/tool/text',
         component: r => require(['./views/tool/text.vue'], r)
     },

--- a/src/views/tool/encrypt.vue
+++ b/src/views/tool/encrypt.vue
@@ -45,6 +45,7 @@ export default {
     methods: {
         handle(v) {
             const sm2 = require('sm-crypto').sm2
+            const sm4 = require('sm-crypto').sm4
             if (this.current.input) {
                 try {
                     let output = ""
@@ -73,14 +74,27 @@ export default {
                                     this.current.password,
                                     this.current.sm2CipherMode
                                 );
+                                output = crypto.enc.Base64.stringify(crypto.enc.Hex.parse(output))
                             } else {
+                                let inputHex = crypto.enc.Hex.stringify(crypto.enc.Base64.parse(this.current.input));
                                 output = sm2.doDecrypt(
-                                    this.current.input,
+                                    inputHex,
                                     this.current.password,
                                     this.current.sm2CipherMode
                                 );
+                                
                             }
                             break;
+                        case "SM4":
+                            if(v === "encrypt") {
+                                // SM4 加密，将输出转换为 base64 格式，与 AES 对齐
+                                output = sm4.encrypt(this.current.input, this.current.password);
+                                output = crypto.enc.Base64.stringify(crypto.enc.Hex.parse(output))
+                            } else {
+                                // SM4 解密，sm-crypto 要求输入为 hex，将 base64 转换为 hex 作为输入
+                                let inputHex = crypto.enc.Hex.stringify(crypto.enc.Base64.parse(this.current.input));
+                                output = sm4.decrypt(inputHex, this.current.password);
+                            }
                     }
                     if (!output) {
                         throw new Error("output null")
@@ -135,7 +149,7 @@ export default {
                 type: "AES",
                 operation: ""
             },
-            type: ["AES", "DES", "RC4", "Rabbit", "TripleDES", "SM2"],
+            type: ["AES", "DES", "RC4", "Rabbit", "TripleDES", "SM2", "SM4"],
             inputHeight: 100,
             outputHeight: 100
         }

--- a/src/views/tool/hex2base64.vue
+++ b/src/views/tool/hex2base64.vue
@@ -1,0 +1,70 @@
+<template>
+    <heightResize ignore :append="['.page-option-block']" @resize="resize">
+        <autoHeightTextarea v-model="current.input" :height="inputHeight" :placeholder="$t('hexString_input')"/>
+        <option-block class="page-option-block">
+            <FormItem>
+                <ButtonGroup>
+                    <Button type="primary" @click="handle('hex')">Base64 -> Hex</Button>
+                    <Button type="primary" @click="handle('base64')">Hex -> Base64</Button>
+                </ButtonGroup>
+            </FormItem>
+            <FormItem>
+                <Checkbox v-model="current.isUppercase">{{ $t('hexString_uppercase') }}</Checkbox>
+            </FormItem>
+        </option-block>
+        <autoHeightTextarea :value="current.output" :height="outputHeight" :placeholder="$t('hexString_output')"/>
+    </heightResize>
+</template>
+<script>
+import CryptoJS from "crypto-js"
+import heightResize from "./components/heightResize";
+import autoHeightTextarea from "./components/autoHeightTextarea";
+
+export default {
+    components: {
+        heightResize,
+        autoHeightTextarea
+    },
+    created() {
+        this.$initToolData('input')
+    },
+    methods: {
+        handle(type) {
+            if (this.current.input) {
+                switch (type) {
+                    case "hex":
+                        this.current.output = CryptoJS.enc.Hex.stringify(CryptoJS.enc.Base64.parse(this.current.input));
+                        break;
+                    case "base64":
+                        this.current.output = CryptoJS.enc.Base64.stringify(CryptoJS.enc.Hex.parse(this.current.input));
+                        break;
+                    default:
+                        return;
+                }
+                if (this.current.isUppercase && type === "hex") {
+                    this.current.output = this.current.output.toUpperCase()
+                }
+                this.current.operation = type;
+                this.$clipboardCopy(this.current.output);
+                this.$saveToolData(this.current);
+            }
+        },
+        resize(height) {
+            this.inputHeight = Math.min(160, Math.ceil(height / 2))
+            this.outputHeight = height - this.inputHeight
+        }
+    },
+    data() {
+        return {
+            current: {
+                input: "",
+                isUppercase: false,
+                output: "",
+                operation: ""
+            },
+            inputHeight: 100,
+            outputHeight: 100
+        }
+    },
+}
+</script>


### PR DESCRIPTION
1. 添加 SM4/ECB/Pkcs7Padding 对称加解密。
2. 添加 Hex/Base64 互转方法。
3. 调整 SM2 的密文格式为 base64，与其他的加解密方法输出格式保持一致。