### PR TITLE
bugfix:参数填充

### DIFF
--- a/packages/ctool-core/src/tools/sqlFillParameter/SqlFillParameter.vue
+++ b/packages/ctool-core/src/tools/sqlFillParameter/SqlFillParameter.vue
@@ -3,23 +3,23 @@
         <Align direction="vertical">
             <div v-row="`1-1`">
                 <Textarea
-                    v-model="action.current.input"
-                    :height="height/2"
-                    :placeholder="`Sql:SELECT * FROM T WHERE id=? AND name = ?`"
-                    copy="Sql"
+                        v-model="action.current.input"
+                        :height="height/2"
+                        :placeholder="`Sql:SELECT * FROM T WHERE id=? AND name = ?`"
+                        copy="Sql"
                 />
                 <Textarea
-                    v-model="action.current.params"
-                    :height="height/2"
-                    :placeholder="`${$t('sqlFillParameter_parameter')}:1(Integer),zhangshan(String)`"
-                    :copy="$t('sqlFillParameter_parameter')"
+                        v-model="action.current.params"
+                        :height="height/2"
+                        :placeholder="`${$t('sqlFillParameter_parameter')}:1(Integer),zhangshan(String)`"
+                        :copy="$t('sqlFillParameter_parameter')"
                 />
             </div>
             <Textarea
-                :model-value="output"
-                copy
-                :height="height/2"
-                :placeholder="`${$t('main_ui_output')}:SELECT * FROM T WHERE id=1 AND name='zhangshan'`"
+                    :model-value="output"
+                    copy
+                    :height="height/2"
+                    :placeholder="`${$t('main_ui_output')}:SELECT * FROM T WHERE id=1 AND name='zhangshan'`"
             />
         </Align>
     </HeightResize>
@@ -47,7 +47,8 @@ const convertParam = (params: string) => {
         return paramStrList.map(x => {
             let valueEndIndex = x.lastIndexOf('(')
             if (valueEndIndex < 0) {
-                throw new Error($t('sqlFillParameter_invalid_param', [x]))
+                // 直接将整个串作为值，类型为其他
+                return {value: x, type: null}
             }
             // 从串中截取出值，并对前后空格进行清除
             let value = x.substring(0, valueEndIndex)
@@ -121,18 +122,22 @@ const fill = () => {
 const splitSqlAndParams = () => {
     let tempStr = action.current.input
     if (tempStr) {
-        let sqlStr, paramStr
+        let sqlStr = '', paramStr = ''
         // 寻找SQL串的开始
         let sqlStartStr = 'Preparing:'
         let sqlStartIndex = tempStr.indexOf(sqlStartStr)
-        if (sqlStartIndex >= 0) {
-            // mybatis打印的SQL都以行为结束标记，因此寻找到该行的\n即认为结束
-            let sqlEndIndex = tempStr.indexOf("\n", sqlStartIndex)
-            if (sqlEndIndex < 0) {
-                sqlEndIndex = tempStr.length
-            }
-            sqlStr = tempStr.substring(sqlStartIndex + sqlStartStr.length, sqlEndIndex)
+        if (sqlStartIndex < 0) {
+            // 没有找到Preparing:则认为整个串是SQL
+            sqlStartIndex = 0
+        } else {
+            sqlStartIndex += sqlStartStr.length
         }
+        // mybatis打印的SQL都以行为结束标记，因此寻找到该行的\n即认为结束
+        let sqlEndIndex = tempStr.indexOf("\n", sqlStartIndex)
+        if (sqlEndIndex < 0) {
+            sqlEndIndex = tempStr.length
+        }
+        sqlStr = tempStr.substring(sqlStartIndex, sqlEndIndex)
         // 寻找参数串的开始
         let paramStartStr = 'Parameters:'
         let paramStartIndex = tempStr.indexOf(paramStartStr)

--- a/packages/ctool-core/src/tools/sqlFillParameter/SqlFillParameter.vue
+++ b/packages/ctool-core/src/tools/sqlFillParameter/SqlFillParameter.vue
@@ -168,10 +168,9 @@ const output = $computed(() => {
 watch(() => {
     return {input: action.current.input, params: action.current.params}
 }, ({input, params}) => {
-    // 如果参数为空，且输入不为空，且输入包含Preparing:和Parameters:，则尝试分离SQL和参数
+    // 输入不为空，且输入包含Preparing:和Parameters:，则尝试分离SQL和参数
     if (
-        params === ""
-        && input !== ""
+        input !== ""
         && input.includes('Preparing:')
         && input.includes('Parameters:')
     ) {

--- a/packages/ctool-core/src/tools/sqlFillParameter/i18n/en.json5
+++ b/packages/ctool-core/src/tools/sqlFillParameter/i18n/en.json5
@@ -1,5 +1,4 @@
 {
-    "invalid_param": "Invalid Parameter: {0}",
     'parameter': 'Parameter',
     'parameter_too_little': 'No Enough Parameters',
 }

--- a/packages/ctool-core/src/tools/sqlFillParameter/i18n/zh_CN.json5
+++ b/packages/ctool-core/src/tools/sqlFillParameter/i18n/zh_CN.json5
@@ -1,5 +1,4 @@
 {
-    "invalid_param": "无效的参数: {0}",
     'parameter': '参数',
     'parameter_too_little': '参数个数不足',
 }


### PR DESCRIPTION
1. 修复了insert语句插入null值，没有类型的这种情况无法做参数填充
2. 修复了简单SQL无法输入的转换的问题。 因为添加了参数分离功能，原功能（分别复制一个SQL和参数进去）失效

测试数据：
问题1：
---------com.xxx :Preparing: insert into xxx (id,xx) values(?,?)
--Parameters: String(String), null

问题2： 
SQL:
SELECT * FROM xxx where x=?
参数： 
String(String)