### PR TITLE
添加SQL参数填充对json的支持

### DIFF
--- a/packages/ctool-core/src/tools/sqlFillParameter/SqlFillParameter.vue
+++ b/packages/ctool-core/src/tools/sqlFillParameter/SqlFillParameter.vue
@@ -41,25 +41,61 @@ const action = useAction(await initialize({input: "", params: ""}))
  */
 const convertParam = (params: string) => {
     if (params) {
-        let paramStrList = params.split(',', -1)
+        let tempList = params.split(',', -1)
+        // 因为参数中可能存在逗号，例如json数据，为此采取的方案是先分割，后合并的策略
+        // 分割后是不包含,的，检查串是否为null或者)结尾，如果是则认为是正常的参数，如果不是则认为是分割后的串的一部分
+        // 举例{"goodsService":[],"goodsSpecs":{"id":"db6c56a224a788c5a7458017731c9255","imageFileId":"16925e7fc297452a984d4b3e2e9e6e40"}}(String),
+        // null, null, 1(Integer),1(Integer)
+        // paramStrList 为合并后的实际参数列表
+        let paramStrList:string[] = []
+        let paramIndex = 0
+        // 标记是否在合并中
+        let combining = false
+        tempList.forEach((x) => {
+            // 对null值采用endsWith的原因是因为有前置空格，直接判断endWith比去掉空格处理更方便
+            // 遇到null值直接作为参数
+            if (x.endsWith('null')) {
+              paramStrList.push(x)
+              paramIndex ++
+            } else if (x.endsWith(')')) {
+                // 前面的串处在合并过程中，遇到了）结尾的情况，说明合并结束
+                if (combining) {
+                    paramStrList[paramIndex] += ',' + x
+                    combining = false
+                } else {
+                    paramStrList.push(x)
+                }
+                paramIndex ++
+            } else {
+                let tempStr = paramStrList[paramIndex]
+                if (!tempStr) {
+                  paramStrList.push(x)
+                  combining= true
+                } else {
+                  paramStrList[paramIndex] +=  ',' + x
+                }
+            }
+        })
         return paramStrList.map(x => {
             let valueEndIndex = x.lastIndexOf('(')
             if (valueEndIndex < 0) {
-                // 直接将整个串作为值，类型为其他
-                return {value: x, type: null}
+              // 直接将整个串作为值，类型为其他
+              return {value: x, type: null}
             }
             // 从串中截取出值，并对前后空格进行清除
             let value = x.substring(0, valueEndIndex)
             value = value.trim();
+            // 对数据中的'进行转义，mybatis输出的参数中的'是不进行转义的
+            value = value.replaceAll('\'', '\\\'')
             // 从串中截取出类型，并进行前后空格清除
             let typeEndIndex = x.lastIndexOf(')')
             if (typeEndIndex < 0) {
-                typeEndIndex = x.length
+              typeEndIndex = x.length
             }
             let type = x.substring(valueEndIndex + 1, typeEndIndex)
             type = type.trim()
             return {value, type}
-        })
+          })
     } else {
         return []
     }

--- a/packages/ctool-core/src/tools/sqlFillParameter/SqlFillParameter.vue
+++ b/packages/ctool-core/src/tools/sqlFillParameter/SqlFillParameter.vue
@@ -79,8 +79,8 @@ const convertParam = (params: string) => {
         return paramStrList.map(x => {
             let valueEndIndex = x.lastIndexOf('(')
             if (valueEndIndex < 0) {
-              // 直接将整个串作为值，类型为其他
-              return {value: x, type: null}
+                // 直接将整个串作为值，类型为其他
+                return {value: x, type: null}
             }
             // 从串中截取出值，并对前后空格进行清除
             let value = x.substring(0, valueEndIndex)
@@ -90,12 +90,12 @@ const convertParam = (params: string) => {
             // 从串中截取出类型，并进行前后空格清除
             let typeEndIndex = x.lastIndexOf(')')
             if (typeEndIndex < 0) {
-              typeEndIndex = x.length
+                typeEndIndex = x.length
             }
             let type = x.substring(valueEndIndex + 1, typeEndIndex)
             type = type.trim()
             return {value, type}
-          })
+        })
     } else {
         return []
     }


### PR DESCRIPTION
#250 

bugfix:SQL参数填充

1. 修复传参为json的时候无法进行sql填充，提示参数错误的问题。这个修复逻辑是先进行,分割，再考虑将分割错误的数据通过特定的标记合并起来。

2. 修复当参数中含有'没有进行转义的问题

测试数据：
UPDATE site_config SET site_title = ?, site_subtitle = ?, logo_path = ?, favicon_path = ? WHERE id = ? AND X=?
XXXX(String), ,(String)(String), null, {"goodsService":[],"goodsSpecs":{"id":"db6c56a224a788c5a7458017731c9255","imageFileId":"16925e7fc297452a984d4b3e2e9e6e40"}}(String), 1(Integer), '(String)