### PR TITLE
Feature/HexToString allow hex to string convert unicode escape

### DIFF
--- a/packages/ctool-core/src/helper/text/index.ts
+++ b/packages/ctool-core/src/helper/text/index.ts
@@ -79,6 +79,7 @@ class Text {
         return Text.fromBuffer(
             Buffer.from(
                 str
+                    .replaceAll(/\\x/g, '') // 兼容 Unicode Escape 格式
                     .replaceAll(" ", "") // 过滤空格
                     .replaceAll("\n", preserve_line_breaks ? "0a" : "") // 换行符处理
                     .trim(),
@@ -86,7 +87,6 @@ class Text {
             ),
         );
     }
-
     static fromBuffer(item: Buffer): Text {
         return Text.fromUint8Array(Uint8Array.from(item));
     }


### PR DESCRIPTION
允许转换 unicode escape 格式如: \xe5\xb9\xbf\xe5\x91\x8a\xe5\xa4\xb1\xe8\xb4\xa5 

https://www.bejson.com/convert/ox2str/