### PR TITLE
fix: 切换页面报错 (fix #306)

### DIFF
--- a/packages/ctool-core/src/components/Modal.vue
+++ b/packages/ctool-core/src/components/Modal.vue
@@ -76,12 +76,12 @@ const clickClose = (event: MouseEvent) => {
 }
 
 const open = () => {
-    if (!container) {
+        if (!container) {
         return;
     }
     container.show()
     setTimeout(() => {
-        document.addEventListener('click', clickClose)
+        container && document.addEventListener('click', clickClose)
     }, 300)
 }
 
@@ -96,7 +96,7 @@ const close = () => {
         return;
     }
     setTimeout(() => {
-        container.close()
+        container && container.close()
         emit('close')
     }, 300)
     document.removeEventListener('click', clickClose);
@@ -107,7 +107,7 @@ const update = () => {
 }
 watch(() => show, () => update())
 onMounted(() => {
-    update()
+        update()
     // esc 关闭
     document.addEventListener('keydown', event => {
         if (event.key === 'Escape') {


### PR DESCRIPTION
函数执行时 container 存在，但 setTimeout 回调执行时 container 可能已被销毁，这导致快速点击时（300ms以内）报错。

https://github.com/baiy/Ctool/blob/60ceb1d200d1386d539472e5a3fcd401bddec125/packages/ctool-core/src/components/Modal.vue#L99

以及可能导致注册无效的事件：

https://github.com/baiy/Ctool/blob/60ceb1d200d1386d539472e5a3fcd401bddec125/packages/ctool-core/src/components/Modal.vue#L84
