### PR TITLE
使gzip解压后的数据支持hex和base64

### DIFF
--- a/packages/ctool-core/src/tools/gzip/Decoder.vue
+++ b/packages/ctool-core/src/tools/gzip/Decoder.vue
@@ -10,7 +10,7 @@
             />
             <TextOutput
                 v-model="action.current.output"
-                :allow="['text']"
+                :allow="['text','base64', 'hex']"
                 :content="output"
                 :height="large"
                 @success="action.save()"


### PR DESCRIPTION
有时候gzip解压后的数据还需要进行其他处理，才能得到想要的数据