### PR TITLE
add sidepanel

### DIFF
--- a/packages/ctool-adapter/chrome/resources/manifest_v3.json
+++ b/packages/ctool-adapter/chrome/resources/manifest_v3.json
@@ -22,7 +22,8 @@
     },
     "permissions": [
         "clipboardWrite",
-        "clipboardRead"
+        "clipboardRead",
+        "sidePanel"
     ],
     "host_permissions": [
         "*://get.geojs.io/*",
@@ -35,6 +36,9 @@
             "description": "__MSG_main_manifest_commands_panel_description__",
             "global": true
         }
+    },
+    "side_panel": {
+        "default_path": "index.html"
     },
     "update_url": "http://clients2.google.com/service/update2/crx"
 }


### PR DESCRIPTION
Example of a decryption scenario: Users need to input ciphertext and keys, which typically requires multiple copy-paste actions. In this case, losing focus may cause the popup to close, and reopening it would clear the previously entered content. Therefore, it is recommended to use a side panel mode that remains fixed on one side.